### PR TITLE
Fix product search refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## To be released
 - Fix refine option processing to include refine_1 ... refine_n alternatives
+- Fix rollup format 'cjs' --> 'es'
 
 ## v0.1.0 (November 6, 2017)
 - Module name change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Fix refine option processing to include refine_1 ... refine_n alternatives
+
 ## v0.1.0 (November 6, 2017)
 - Module name change
 - Add ASCII art

--- a/docs/ApiClient.js.html
+++ b/docs/ApiClient.js.html
@@ -347,6 +347,32 @@ export default class ApiClient {
     }
 
     /**
+     * Builds an object with refinement keys 1..n given a options object..
+     * @param {Object} opts Optional parameters
+     * @returns {Object} An object with refinement keys numbered 1 ... n with their
+     * string representation value.
+     */
+    buildRefineParams(opts) {
+        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
+        const queryParams = {}
+
+        if (refinements.length > 0) {
+            const useSuffix = refinements.length > 1
+
+            refinements.forEach((key, idx) => {
+                if (!opts[key]) {
+                    return
+                }
+
+                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
+                    this.buildCollectionParam(opts[key], 'csv')
+            })
+        }
+
+        return queryParams
+    }
+
+    /**
      * Applies authentication headers to the request.
      * @param {Object} request The request object created by a &lt;code>superagent()&lt;/code> call.
      * @param {Array.&lt;String>} authNames An array of authentication method names.

--- a/docs/api_ContentSearchApi.js.html
+++ b/docs/api_ContentSearchApi.js.html
@@ -99,20 +99,7 @@ export default class ContentSearchApi {
             locale: opts.locale
         }
 
-        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
-
-        if (refinements) {
-            const useSuffix = refinements.length > 0
-
-            refinements.forEach((key, idx) => {
-                if (!opts[key]) {
-                    return
-                }
-
-                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
-                    this.apiClient.buildCollectionParam(opts[key], 'csv')
-            })
-        }
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
 
         const headerParams = {}
         const formParams = {}

--- a/docs/api_ContentSearchApi.js.html
+++ b/docs/api_ContentSearchApi.js.html
@@ -93,12 +93,27 @@ export default class ContentSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: this.apiClient.buildCollectionParam(opts.sort, 'csv'),
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
+
+        if (refinements) {
+            const useSuffix = refinements.length > 0
+
+            refinements.forEach((key, idx) => {
+                if (!opts[key]) {
+                    return
+                }
+
+                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
+                    this.apiClient.buildCollectionParam(opts[key], 'csv')
+            })
+        }
+
         const headerParams = {}
         const formParams = {}
 

--- a/docs/api_ProductSearchApi.js.html
+++ b/docs/api_ProductSearchApi.js.html
@@ -103,20 +103,7 @@ export default class ProductSearchApi {
             locale: opts.locale
         }
 
-        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
-
-        if (refinements) {
-            const useSuffix = refinements.length > 0
-
-            refinements.forEach((key, idx) => {
-                if (!opts[key]) {
-                    return
-                }
-
-                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
-                    this.apiClient.buildCollectionParam(opts[key], 'csv')
-            })
-        }
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
 
         const headerParams = {}
         const formParams = {}
@@ -198,12 +185,14 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 
@@ -279,12 +268,14 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 
@@ -361,13 +352,15 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             currency: opts.currency,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 
@@ -442,12 +435,14 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 

--- a/docs/api_ProductSearchApi.js.html
+++ b/docs/api_ProductSearchApi.js.html
@@ -95,7 +95,6 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
@@ -103,6 +102,22 @@ export default class ProductSearchApi {
             currency: opts.currency,
             locale: opts.locale
         }
+
+        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
+
+        if (refinements) {
+            const useSuffix = refinements.length > 0
+
+            refinements.forEach((key, idx) => {
+                if (!opts[key]) {
+                    return
+                }
+
+                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
+                    this.apiClient.buildCollectionParam(opts[key], 'csv')
+            })
+        }
+
         const headerParams = {}
         const formParams = {}
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,7 +52,7 @@ _(___ _(___/_/_/__/_/_/__/_(___ _/_____(___ _(___ _(___ _/___(___/_(___(__(___/_
                                                                                                          /                                             
                                                                                                         /</code></pre><p><a href="https://nodei.co/npm/commercecloud-ocapi-client/"><img src="https://nodei.co/npm/commercecloud-ocapi-client.png?downloads=true&amp;stars=true" alt="NPM"></a></p>
 <p><a href="https://circleci.com/gh/mobify/commercecloud-ocapi-client"><img src="https://circleci.com/gh/mobify/commercecloud-ocapi-client.svg?style=svg" alt="CircleCI"></a></p>
-<h2>Introduction</h2><p>ShopApi - JavaScript client for Salesforce Commerce Cloud OCAPI Shop API.</p>
+<h2>Introduction</h2><p>ShopApi - ES6 JavaScript client for Salesforce Commerce Cloud OCAPI Shop API.</p>
 <ul>
 <li>API version: 17.8</li>
 </ul>

--- a/docs/module-ApiClient.html
+++ b/docs/module-ApiClient.html
@@ -732,7 +732,7 @@ response, and return them in the next request.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line606">line 606</a>
+        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line632">line 632</a>
     </li></ul></dd>
     
 
@@ -905,7 +905,7 @@ all properties on <code>data<code> will be converted to this type.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line529">line 529</a>
+        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line555">line 555</a>
     </li></ul></dd>
     
 
@@ -1050,7 +1050,7 @@ all properties on <code>data<code> will be converted to this type.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line516">line 516</a>
+        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line542">line 542</a>
     </li></ul></dd>
     
 
@@ -1230,7 +1230,7 @@ all properties on <code>data<code> will be converted to this type.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line326">line 326</a>
+        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line352">line 352</a>
     </li></ul></dd>
     
 
@@ -1431,6 +1431,164 @@ all properties on <code>data<code> will be converted to this type.</p></td>
 |
 
 <span class="param-type">Array</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+
+
+
+        
+            
+
+    
+
+    
+    <h4 class="name" id="buildRefineParams"><span class="type-signature"></span>buildRefineParams<span class="signature">(opts)</span><span class="type-signature"> &rarr; {Object}</span></h4>
+    
+
+    
+
+
+
+<div class="description">
+    <p>Builds an object with refinement keys 1..n given a options object..</p>
+</div>
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>opts</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">Object</span>
+
+
+            
+            </td>
+
+            
+
+            
+
+            <td class="description last"><p>Optional parameters</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+<dl class="details">
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line327">line 327</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>An object with refinement keys numbered 1 ... n with their
+string representation value.</p>
+</div>
+
+
+
+<dl>
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">Object</span>
 
 
     </dd>
@@ -1967,7 +2125,7 @@ constructor for a complex type.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line408">line 408</a>
+        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line434">line 434</a>
     </li></ul></dd>
     
 
@@ -2159,7 +2317,7 @@ all properties on <code>data<code> will be converted to this type.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line376">line 376</a>
+        <a href="ApiClient.js.html">ApiClient.js</a>, <a href="ApiClient.js.html#line402">line 402</a>
     </li></ul></dd>
     
 

--- a/docs/module-api_ContentSearchApi.html
+++ b/docs/module-api_ContentSearchApi.html
@@ -473,7 +473,7 @@ Attributes.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ContentSearchApi.js.html">api/ContentSearchApi.js</a>, <a href="api_ContentSearchApi.js.html#line111">line 111</a>
+        <a href="api_ContentSearchApi.js.html">api/ContentSearchApi.js</a>, <a href="api_ContentSearchApi.js.html#line126">line 126</a>
     </li></ul></dd>
     
 

--- a/docs/module-api_ContentSearchApi.html
+++ b/docs/module-api_ContentSearchApi.html
@@ -473,7 +473,7 @@ Attributes.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ContentSearchApi.js.html">api/ContentSearchApi.js</a>, <a href="api_ContentSearchApi.js.html#line126">line 126</a>
+        <a href="api_ContentSearchApi.js.html">api/ContentSearchApi.js</a>, <a href="api_ContentSearchApi.js.html#line113">line 113</a>
     </li></ul></dd>
     
 

--- a/docs/module-api_ProductSearchApi.html
+++ b/docs/module-api_ProductSearchApi.html
@@ -523,7 +523,7 @@ prices, variations)</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line136">line 136</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line123">line 123</a>
     </li></ul></dd>
     
 
@@ -856,7 +856,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line217">line 217</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line206">line 206</a>
     </li></ul></dd>
     
 
@@ -1189,7 +1189,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line166">line 166</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line153">line 153</a>
     </li></ul></dd>
     
 
@@ -1522,7 +1522,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line298">line 298</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line289">line 289</a>
     </li></ul></dd>
     
 
@@ -1855,7 +1855,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line247">line 247</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line236">line 236</a>
     </li></ul></dd>
     
 
@@ -2210,7 +2210,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line381">line 381</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line374">line 374</a>
     </li></ul></dd>
     
 
@@ -2566,7 +2566,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line329">line 329</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line320">line 320</a>
     </li></ul></dd>
     
 
@@ -2898,7 +2898,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line460">line 460</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line455">line 455</a>
     </li></ul></dd>
     
 
@@ -3230,7 +3230,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line410">line 410</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line403">line 403</a>
     </li></ul></dd>
     
 

--- a/docs/module-api_ProductSearchApi.html
+++ b/docs/module-api_ProductSearchApi.html
@@ -523,7 +523,7 @@ prices, variations)</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line121">line 121</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line136">line 136</a>
     </li></ul></dd>
     
 
@@ -856,7 +856,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line202">line 202</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line217">line 217</a>
     </li></ul></dd>
     
 
@@ -1189,7 +1189,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line151">line 151</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line166">line 166</a>
     </li></ul></dd>
     
 
@@ -1522,7 +1522,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line283">line 283</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line298">line 298</a>
     </li></ul></dd>
     
 
@@ -1855,7 +1855,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line232">line 232</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line247">line 247</a>
     </li></ul></dd>
     
 
@@ -2210,7 +2210,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line366">line 366</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line381">line 381</a>
     </li></ul></dd>
     
 
@@ -2566,7 +2566,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line314">line 314</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line329">line 329</a>
     </li></ul></dd>
     
 
@@ -2898,7 +2898,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line445">line 445</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line460">line 460</a>
     </li></ul></dd>
     
 
@@ -3230,7 +3230,7 @@ refinement values are not supported.</p></td>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line395">line 395</a>
+        <a href="api_ProductSearchApi.js.html">api/ProductSearchApi.js</a>, <a href="api_ProductSearchApi.js.html#line410">line 410</a>
     </li></ul></dd>
     
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ export default {
     input: 'src/index.js',
     output: {
         file: 'lib/index.js',
-        format: 'cjs'
+        format: 'es'
     },
     external: ['superagent', 'querystring'],
 }

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -319,6 +319,32 @@ export default class ApiClient {
     }
 
     /**
+     * Builds an object with refinement keys 1..n given a options object..
+     * @param {Object} opts Optional parameters
+     * @returns {Object} An object with refinement keys numbered 1 ... n with their
+     * string representation value.
+     */
+    buildRefineParams(opts) {
+        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
+        const queryParams = {}
+
+        if (refinements.length > 0) {
+            const useSuffix = refinements.length > 1
+
+            refinements.forEach((key, idx) => {
+                if (!opts[key]) {
+                    return
+                }
+
+                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
+                    this.buildCollectionParam(opts[key], 'csv')
+            })
+        }
+
+        return queryParams
+    }
+
+    /**
      * Applies authentication headers to the request.
      * @param {Object} request The request object created by a <code>superagent()</code> call.
      * @param {Array.<String>} authNames An array of authentication method names.

--- a/src/api/ContentSearchApi.js
+++ b/src/api/ContentSearchApi.js
@@ -73,7 +73,7 @@ export default class ContentSearchApi {
 
         const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
 
-        if (refinements) {
+        if (refinements.lengh > 0) {
             const useSuffix = refinements.length > 0
 
             refinements.forEach((key, idx) => {

--- a/src/api/ContentSearchApi.js
+++ b/src/api/ContentSearchApi.js
@@ -73,7 +73,7 @@ export default class ContentSearchApi {
 
         const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
 
-        if (refinements.lengh > 0) {
+        if (refinements.length > 0) {
             const useSuffix = refinements.length > 1
 
             refinements.forEach((key, idx) => {

--- a/src/api/ContentSearchApi.js
+++ b/src/api/ContentSearchApi.js
@@ -74,7 +74,7 @@ export default class ContentSearchApi {
         const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
 
         if (refinements.lengh > 0) {
-            const useSuffix = refinements.length > 0
+            const useSuffix = refinements.length > 1
 
             refinements.forEach((key, idx) => {
                 if (!opts[key]) {

--- a/src/api/ContentSearchApi.js
+++ b/src/api/ContentSearchApi.js
@@ -65,12 +65,27 @@ export default class ContentSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: this.apiClient.buildCollectionParam(opts.sort, 'csv'),
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
+
+        if (refinements) {
+            const useSuffix = refinements.length > 0
+
+            refinements.forEach((key, idx) => {
+                if (!opts[key]) {
+                    return
+                }
+
+                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
+                    this.apiClient.buildCollectionParam(opts[key], 'csv')
+            })
+        }
+
         const headerParams = {}
         const formParams = {}
 

--- a/src/api/ContentSearchApi.js
+++ b/src/api/ContentSearchApi.js
@@ -71,20 +71,7 @@ export default class ContentSearchApi {
             locale: opts.locale
         }
 
-        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
-
-        if (refinements.length > 0) {
-            const useSuffix = refinements.length > 1
-
-            refinements.forEach((key, idx) => {
-                if (!opts[key]) {
-                    return
-                }
-
-                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
-                    this.apiClient.buildCollectionParam(opts[key], 'csv')
-            })
-        }
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
 
         const headerParams = {}
         const formParams = {}

--- a/src/api/ProductSearchApi.js
+++ b/src/api/ProductSearchApi.js
@@ -78,7 +78,7 @@ export default class ProductSearchApi {
         const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
 
         if (refinements.lengh > 0) {
-            const useSuffix = refinements.length > 0
+            const useSuffix = refinements.length > 1
 
             refinements.forEach((key, idx) => {
                 if (!opts[key]) {

--- a/src/api/ProductSearchApi.js
+++ b/src/api/ProductSearchApi.js
@@ -75,20 +75,7 @@ export default class ProductSearchApi {
             locale: opts.locale
         }
 
-        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
-
-        if (refinements.length > 0) {
-            const useSuffix = refinements.length > 1
-
-            refinements.forEach((key, idx) => {
-                if (!opts[key]) {
-                    return
-                }
-
-                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
-                    this.apiClient.buildCollectionParam(opts[key], 'csv')
-            })
-        }
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
 
         const headerParams = {}
         const formParams = {}
@@ -170,12 +157,14 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 
@@ -251,12 +240,14 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 
@@ -333,13 +324,15 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             currency: opts.currency,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 
@@ -414,12 +407,14 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
         }
+
+        Object.assign(queryParams, this.apiClient.buildRefineParams(opts))
+
         const headerParams = {}
         const formParams = {}
 

--- a/src/api/ProductSearchApi.js
+++ b/src/api/ProductSearchApi.js
@@ -77,7 +77,7 @@ export default class ProductSearchApi {
 
         const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
 
-        if (refinements) {
+        if (refinements.lengh > 0) {
             const useSuffix = refinements.length > 0
 
             refinements.forEach((key, idx) => {

--- a/src/api/ProductSearchApi.js
+++ b/src/api/ProductSearchApi.js
@@ -67,7 +67,6 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
@@ -75,6 +74,22 @@ export default class ProductSearchApi {
             currency: opts.currency,
             locale: opts.locale
         }
+
+        const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
+
+        if (refinements) {
+            const useSuffix = refinements.length > 0
+
+            refinements.forEach((key, idx) => {
+                if (!opts[key]) {
+                    return
+                }
+
+                queryParams[`refine${useSuffix ? `_${idx + 1}` : ''}`] =
+                    this.apiClient.buildCollectionParam(opts[key], 'csv')
+            })
+        }
+
         const headerParams = {}
         const formParams = {}
 

--- a/src/api/ProductSearchApi.js
+++ b/src/api/ProductSearchApi.js
@@ -77,7 +77,7 @@ export default class ProductSearchApi {
 
         const refinements = Object.keys(opts).filter((key) => /^refine/.test(key))
 
-        if (refinements.lengh > 0) {
+        if (refinements.length > 0) {
             const useSuffix = refinements.length > 1
 
             refinements.forEach((key, idx) => {

--- a/test/api/PriceAdjustmentLimitsApi.spec.js
+++ b/test/api/PriceAdjustmentLimitsApi.spec.js
@@ -59,14 +59,6 @@ describe('PriceAdjustmentLimitsApi', () => {
             //  if (error) throw error;
             // expect().to.be();
             // });
-            instance.getPriceAdjustmentLimits()
-                .then((thing) => {
-                    console.log('thing: ', thing)
-                })
-                .catch((fault) => {
-                    console.log('fault: ', fault)
-                })
-            return Promise.resolve()
         })
     })
 })

--- a/test/api/ProductSearchApi.spec.js
+++ b/test/api/ProductSearchApi.spec.js
@@ -61,6 +61,17 @@ describe('ProductSearchApi', () => {
                     expect(productSearchResult.count).to.above(0)
                 })
         )
+
+        it('should call getProductSearch with multiple refinments successfully', () =>
+            instance.getProductSearch({
+                    refine_1: ['cgid=root'],
+                    refine_2: ['c_refinementColor=Navy']
+                })
+                .then((productSearchResult) => {
+                    expect(productSearchResult.selected_refinements.cgid).to.be('root')
+                    expect(productSearchResult.selected_refinements.c_refinementColor).to.be('Navy')
+                })
+        )
     })
 
     describe('getProductSearchAvailability', () => {


### PR DESCRIPTION
Api called that used the 'refine' optional parameter didn't process the refine_1...refine_n options, only the 'refine' option. This pr updates the code so that those options are processed and sent to the server.

Status: **Opened for visibility**

## Changes
- Update product search call optional params parsing
- Update content search call optional params parsing
- Removed a incomplete test that had debugging logs in it
- Update docs