### PR TITLE
Fix Rollup Output format to ES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Update Rollup output format to 'es'
+
 ## v0.1.0 (November 6, 2017)
 - Module name change
 - Add ASCII art

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ export default {
     input: 'src/index.js',
     output: {
         file: 'lib/index.js',
-        format: 'cjs'
+        format: 'es'
     },
     external: ['superagent', 'querystring'],
 }


### PR DESCRIPTION
We erroneously left the output format as common js. Because we have left this as a es6 module I need to change the format to 'es' so it can be used properly.

Status: **Opened for visibility**

## Changes
- Change output format in rollup.config
