### PR TITLE
Compile to es5, even when using rollup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,15 @@
 {
-    "presets": [
-        ["env", {"modules": false}]
-    ],
-    "plugins": [
-        "external-helpers"
-    ]
+    "env": {
+        "production": {
+            "presets": [
+                ["env", {"modules": false}]
+            ],
+            "plugins": [
+                "external-helpers"
+            ]
+        },
+        "test": {
+            "presets": ["env"]
+        }
+    }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,15 +1,8 @@
 {
-    "env": {
-        "production": {
-            "presets": [
-                ["env", {"modules": false}]
-            ],
-            "plugins": [
-                "external-helpers"
-            ]
-        },
-        "test": {
-            "presets": ["env"]
-        }
-    }
+    "presets": [
+        ["env", {"modules": false}]
+    ],
+    "plugins": [
+        "external-helpers"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "npm run lint:js -- --fix",
     "test": "NODE_ENV=test mocha --require babel-core/register $(find test/api -name '*.spec.js')",
     "prebuild": "npm run lint",
-    "build": "rollup -c",
+    "build": "NODE_ENV=production rollup -c",
     "prepack": "npm run build"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,4 +37,10 @@ export default [{
         format: 'es'
     }],
     external: ['superagent', 'querystring'],
+    plugins: [
+        babel({
+            exclude: ['node_modules/**'],
+            externalHelpers: true
+        })
+    ]
 }]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,8 +22,7 @@ export default [{
             browser: true,
         }),
         babel({
-            exclude: ['node_modules/**'],
-            externalHelpers: true
+            exclude: ['node_modules/**']
         })
     ]
 },
@@ -39,8 +38,7 @@ export default [{
     external: ['superagent', 'querystring'],
     plugins: [
         babel({
-            exclude: ['node_modules/**'],
-            externalHelpers: true
+            exclude: ['node_modules/**']
         })
     ]
 }]


### PR DESCRIPTION
# Description

I believe we want to compile our sources to ES5 for distribution, regardless of the module pattern we are using with rollout.

For context: React compiles to ES5 - https://github.com/facebook/react/blob/master/.babelrc

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes

- Configure es5 compilation