### PR TITLE
Add `overrideHttpPut` Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Add `allowHttpPut` option for handling environments not allowing http put.
+
 ## v0.1.4 (June 21, 2018)
 - Fix superagent `attachCookies` and `saveCookies` usage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## To be released
-- Add `allowHttpPut` option for handling environments not allowing http put.
+- Add `overrideHttpPut` option for handling environments not allowing http put.
 
 ## v0.1.4 (June 21, 2018)
 - Fix superagent `attachCookies` and `saveCookies` usage

--- a/README.md
+++ b/README.md
@@ -83,12 +83,13 @@ const config = {
   timeout: 60000, // Request timeout in milliseconds
   cache: true, // If set to false an additional timestamp parameter is added to all API GET calls to prevent browser caching
   enableCookies: false, //If set to true, the client will save the cookies from each server response, and return them in the next request.
+  overrideHttpPut: true // If set to true, any methods specified as using http PUT will best sent using POST along the header value 'x-dw-http-method-override' set to 'PUT'.
 }
 
 ShopApi.ApiClient.instance = new ShopApi.ApiClient(config)
 ```
 
-    
+
 
 ### 🔐 Authorization
 
@@ -121,7 +122,7 @@ ShopApi.ApiClient.instance = new ShopApi.ApiClient(config)
 
 Because Salesforce OCAPI is not publicly available, you need to have a running instance that you can test against. In the test folder, there is a file `config.json` that has the example configuration for your environment. Simply update the file with your instance information
 
-Example: 
+Example:
 ```json
 {
   "clientId": "5640cc6b-f5e9-466e-9134-9853e9f9db93",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const config = {
   timeout: 60000, // Request timeout in milliseconds
   cache: true, // If set to false an additional timestamp parameter is added to all API GET calls to prevent browser caching
   enableCookies: false, //If set to true, the client will save the cookies from each server response, and return them in the next request.
-  overrideHttpPut: true // If set to true, any methods specified as using http PUT will best sent using POST along the header value 'x-dw-http-method-override' set to 'PUT'.
+  overrideHttpPut: true // If set to true, any methods specified as using http PUT will be sent using POST along the header value 'x-dw-http-method-override' set to 'PUT'.
 }
 
 ShopApi.ApiClient.instance = new ShopApi.ApiClient(config)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commercecloud-ocapi-client",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -25,12 +25,12 @@ import Fault from './models/Fault'
  */
 
 const defaultConfig = {
-    allowHttpPut: false,
     basePath: 'https://localhost/s/siteId/dw/shop/v17_8',
-    defaultHeaders: {},
-    timeout: 60000,
     cache: true,
+    defaultHeaders: {},
     enableCookies: false,
+    overrideHttpPut: true,
+    timeout: 60000,
 }
 
 /**
@@ -44,7 +44,6 @@ export default class ApiClient {
 
     constructor(config = defaultConfig) {
         const {
-            allowHttpPut,
             basePath,
             defaultHeaders,
             timeout,
@@ -52,7 +51,8 @@ export default class ApiClient {
             enableCookies,
             clientUsername,
             clientPassword,
-            oauth2AccessToken
+            oauth2AccessToken,
+            overrideHttpPut
         } = Object.assign(defaultConfig, config)
 
         // verify the required parameter 'basepath' is set
@@ -97,14 +97,14 @@ export default class ApiClient {
         }
 
         /**
-         * If set to false endpoints that normally use HTTP `PUT` will
-         * be sent using `POST`, with an aditional header (x-dw-http-method-override: `PUT`).
+         * If set to true, endpoints that normally use HTTP `PUT` will
+         * be sent using `POST` with an aditional header (x-dw-http-method-override: `PUT`).
          * Please refer to the following Salesforce documentation {@link https://documentation.demandware.com/DOC1/topic/com.demandware.dochelp/OCAPI/18.8/usage/HttpMethods.html}
          * for more information.
          * @type {Boolean}
          * @default false
          */
-        this.allowHttpPut = allowHttpPut
+        this.overrideHttpPut = overrideHttpPut
 
         /**
          * The default HTTP headers to be included for all API calls.
@@ -433,7 +433,7 @@ export default class ApiClient {
         }
 
         // emulate PUT method because they are not allowed on staging and production environments
-        if (!this.allowHttpPut && httpMethod.toUpperCase() === 'PUT') {
+        if (this.overrideHttpPut && httpMethod.toUpperCase() === 'PUT') {
             httpMethod = 'POST'
             headerParams = Object.assign(headerParams || {}, {'x-dw-http-method-override': 'PUT'})
         }

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -97,9 +97,8 @@ export default class ApiClient {
         }
 
         /**
-         * If set to false endpoints normally sent using the HTTP method `PUT` will
-         * be sent using `POST`, with an aditional header (x-dw-http-method-override)
-         * set to `PUT`.
+         * If set to false endpoints that normally use HTTP `PUT` will
+         * be sent using `POST`, with an aditional header (x-dw-http-method-override: `PUT`).
          * Please refer to the following Salesforce documentation {@link https://documentation.demandware.com/DOC1/topic/com.demandware.dochelp/OCAPI/18.8/usage/HttpMethods.html}
          * for more information.
          * @type {Boolean}
@@ -433,7 +432,7 @@ export default class ApiClient {
             queryParams._ = new Date().getTime()
         }
 
-        // emulate PUT method is they are not allowed
+        // emulate PUT method because they are not allowed on staging and production environments
         if (!this.allowHttpPut && httpMethod.toUpperCase() === 'PUT') {
             httpMethod = 'POST'
             headerParams = Object.assign(headerParams || {}, {'x-dw-http-method-override': 'PUT'})

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -102,7 +102,7 @@ export default class ApiClient {
          * Please refer to the following Salesforce documentation {@link https://documentation.demandware.com/DOC1/topic/com.demandware.dochelp/OCAPI/18.8/usage/HttpMethods.html}
          * for more information.
          * @type {Boolean}
-         * @default false
+         * @default true
          */
         this.overrideHttpPut = overrideHttpPut
 


### PR DESCRIPTION
# Description

This change added a new option to the api. `overrideHttpPut` which is defaulted to`false` that will ensure all commands that using http `PUT` as specified in their swagger doc will masquerade as http `POST`. Their http method will then be overridden with an additional header `x-dw-http-method-override: 'PUT'` to ensure things work server side.

This was done on the API side for security reasons, so it is out of our hands. More information about this can be found here --> https://documentation.demandware.com/DOC1/index.jsp?topic=%2Fcom.demandware.dochelp%2FOCAPI%2F18.8%2Fusage%2FHttpMethods.html

<!-- If this PR fixes an issue, please specify issue #. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes

- Add new logic to callAPI method to use POST when allowHttpPut is false and the method type is put.
- Updated change log
- Added option and function docs

# How to test this PR?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project (`npm run lint`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (`README.md` and `CHANGELOG.md`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`npm test`)