### PR TITLE
Ensure PUT Override Happens Before Request Object Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Fix `overrideHttpPut` logic invocation
+
 ## v0.1.5 (October 16, 2018)
 - Add `overrideHttpPut` option for handling environments not allowing http put.
 

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -421,6 +421,12 @@ export default class ApiClient {
         queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
         returnType) {
 
+        // emulate PUT method because they are not allowed on staging and production environments
+        if (this.overrideHttpPut && httpMethod.toUpperCase() === 'PUT') {
+            httpMethod = 'POST'
+            headerParams = Object.assign(headerParams || {}, {'x-dw-http-method-override': 'PUT'})
+        }
+
         const url = this.buildUrl(path, pathParams)
         const request = superagent(httpMethod, url)
 
@@ -430,12 +436,6 @@ export default class ApiClient {
         // set query parameters
         if (httpMethod.toUpperCase() === 'GET' && this.cache === false) {
             queryParams._ = new Date().getTime()
-        }
-
-        // emulate PUT method because they are not allowed on staging and production environments
-        if (this.overrideHttpPut && httpMethod.toUpperCase() === 'PUT') {
-            httpMethod = 'POST'
-            headerParams = Object.assign(headerParams || {}, {'x-dw-http-method-override': 'PUT'})
         }
 
         request.query(this.normalizeParams(queryParams))


### PR DESCRIPTION
# Description

Logic to override http put method should have been done before the request object was created. This pr fixes that. It was missed due to overzealous undo's in my editor.

<!-- If this PR fixes an issue, please specify issue #. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes

- Move override logic above request creation
