### PR TITLE
Update Circle NPM Authentication Method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              # NPM login based on env variables
-              echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
+              # Add NPM token to allow publishing from Circle
+              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+
               npm publish
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Use NPM authentication token for circleci publishing.
+
 ## v0.1.10 (July 2, 2019)
 - Run security audit and upgrade offending npm dependencies. [#23](https://github.com/mobify/commercecloud-ocapi-client/pull/23)
 


### PR DESCRIPTION
# Description

Previously we were logging into npm using the `npm login` command and piping a clever one line string with all the credentials. For some unknown reason this stopped working. The suggested approach is to use an npm authentication token and add it to the `.npmrc` file before running `npm publish` this PR does this.

NOTE: We aren't doing to do a release for this change as it doesn't have anything to do with the project code itself. It'll be released with the next logical change to the code base.