### PR TITLE
Update refinement params

### DIFF
--- a/src/api/ProductSearchApi.js
+++ b/src/api/ProductSearchApi.js
@@ -67,13 +67,17 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             expand: this.apiClient.buildCollectionParam(opts.expand, 'csv'),
             currency: opts.currency,
             locale: opts.locale
+        }
+        if (Array.isArray(opts.refine)) {
+            opts.refine.forEach((value, index) => {
+              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+            })
         }
         const headerParams = {}
         const formParams = {}
@@ -155,11 +159,15 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
+        }
+        if (Array.isArray(opts.refine)) {
+            opts.refine.forEach((value, index) => {
+              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+            })
         }
         const headerParams = {}
         const formParams = {}
@@ -236,11 +244,15 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
+        }
+        if (Array.isArray(opts.refine)) {
+            opts.refine.forEach((value, index) => {
+              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+            })
         }
         const headerParams = {}
         const formParams = {}
@@ -318,12 +330,16 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             currency: opts.currency,
             locale: opts.locale
+        }
+        if (Array.isArray(opts.refine)) {
+            opts.refine.forEach((value, index) => {
+              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+            })
         }
         const headerParams = {}
         const formParams = {}
@@ -399,11 +415,15 @@ export default class ProductSearchApi {
         const pathParams = {}
         const queryParams = {
             q: opts.q,
-            refine: this.apiClient.buildCollectionParam(opts.refine, 'csv'),
             sort: opts.sort,
             start: opts.start,
             count: opts.count,
             locale: opts.locale
+        }
+        if (Array.isArray(opts.refine)) {
+            opts.refine.forEach((value, index) => {
+              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+            })
         }
         const headerParams = {}
         const formParams = {}

--- a/src/api/ProductSearchApi.js
+++ b/src/api/ProductSearchApi.js
@@ -76,7 +76,7 @@ export default class ProductSearchApi {
         }
         if (Array.isArray(opts.refine)) {
             opts.refine.forEach((value, index) => {
-              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+                queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
             })
         }
         const headerParams = {}
@@ -166,7 +166,7 @@ export default class ProductSearchApi {
         }
         if (Array.isArray(opts.refine)) {
             opts.refine.forEach((value, index) => {
-              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+                queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
             })
         }
         const headerParams = {}
@@ -251,7 +251,7 @@ export default class ProductSearchApi {
         }
         if (Array.isArray(opts.refine)) {
             opts.refine.forEach((value, index) => {
-              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+                queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
             })
         }
         const headerParams = {}
@@ -338,7 +338,7 @@ export default class ProductSearchApi {
         }
         if (Array.isArray(opts.refine)) {
             opts.refine.forEach((value, index) => {
-              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+                queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
             })
         }
         const headerParams = {}
@@ -422,7 +422,7 @@ export default class ProductSearchApi {
         }
         if (Array.isArray(opts.refine)) {
             opts.refine.forEach((value, index) => {
-              queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
+                queryParams[`refine_${index + 1}`] = this.apiClient.paramToString(value)
             })
         }
         const headerParams = {}


### PR DESCRIPTION
…f OCAPI

# Description

From support ticket https://support.mobify.com/a/tickets/5541

This change modifies how refine parameters are set so that it matches the format outlined in https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2FOCAPI%2F16.9%2Fshop%2FResources%2FProductSearch.html

That is: `refine_1=`, `refine_2=` rather than just separating with a comma.

Currently, the changes in this PR are applied in several places throughout ProductSearchAPI.js. We might be able to pull some of this into the SDK to avoid repetition.

<!-- If this PR fixes an issue, please specify issue #. -->

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How to test this PR?

The code itself is untested. The changes were tested in Postman to make sure this type of change would work.

# Checklist:

- [X] My code follows the style guidelines of this project (`npm run lint`)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (`README.md` and `CHANGELOG.md`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`npm test`)